### PR TITLE
Default root to default-directory if not in a project

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -590,7 +590,7 @@ Selects a virtualenv in the follow order:
 4. A directory in `pet-venv-dir-names' in the project root if found.
 5. If the current project is using `pyenv', return the path to the virtualenv
    directory by looking up the prefix from `.python-version'."
-  (let ((root (pet-project-root)))
+  (let ((root (or (pet-project-root) default-directory)))
     (or (assoc-default root pet-project-virtualenv-cache)
         (when-let ((ev (getenv "VIRTUAL_ENV")))
           (expand-file-name ev))


### PR DESCRIPTION
Thanks for this package, I am using it in `eshell` to automatically "activate" venvs for the current eshell dir with the following snippet:

```lisp
  (defun my:eshell-insert-pet-venv (path)
    "Advice for adding python venv to eshell PATH."
    (if-let ((venv (pet-virtualenv-root)))
        (cons (expand-file-name "bin/" venv) path)
      path))

  (defun my:enable-eshell-pet ()
    "Automatically activate python env in eshell."
    (interactive)
    (advice-add #'eshell-get-path :filter-return #'my:eshell-insert-pet-venv))
  
  (defun my:disable-eshell-pet ()
    (advice-remove #'eshell-get-path #'my:eshell-insert-pet-venv))

```

This works well for directories in recognized projects. When visiting a non-project directory with a venv, however, I run into a problem with `pet-virtualenv-root`  returning the cached venv value even when leaving to another directory with no venv. I traced this to `pet-virtualenv-root` caching the venv location with a `root` key of `nil` (since `pet-project-root` returns nil). Since this root is used for all non-project dirs, `pet-virtualenv-root` returns an incorrect value for all the non-project dirs visited after the first one with a recognized venv.

For example, to reproduce with the above code, I can run:
```shell
cd /tmp
python -m venv venv
which python3  # /tmp/venv/bin/python3, as expected
cd / 
which python3  # still /tmp/venv/bin/python3,  expected system python
```

To fix, I just added a default of the current default-directory to the value of `root` used in `pet-virtualenv-root`, which causes it to correctly associate the found venv with the searched directory, regardless of whether it is in a project or not. Alternatively, we could not cache venvs with a `root` of nil, but I figured it would be better like this since `root` is only used by the caching mechanism here anyways.