### PR TITLE
Let user customize conda root, and check env vars.

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -113,6 +113,11 @@ and nil otherwise."
   :group 'pet
   :type '(repeat string))
 
+(defcustom pet-condaish-root nil
+  "Absolute path to the root directory where conda/(micro)mamba environments are stored."
+  :group 'pet
+  :type string)
+
 
 
 (defun pet--executable-find (command &optional remote)
@@ -537,6 +542,19 @@ must both be installed into the current project first."
        (concat (file-name-as-directory repo-dir) "py_env-*")
        t)))))
 
+(defun pet-condaish-env-path ()
+  "Get the path to the current conda/(micro)mamba environment based on environment variables `pet-condaish-root'."
+  (let ((root
+         (or pet-condaish-root
+             (getenv "CONDA_ROOT")
+             (getenv "MAMBA_ROOT_PREFIX"))))
+    (if root
+        (concat (file-name-as-directory root)
+                "envs/"
+                (alist-get 'name (pet-environment)))
+      nil)))
+
+
 
 
 ;;;###autoload
@@ -606,6 +624,7 @@ Selects a virtualenv in the follow order:
                                     (let* ((prefix (alist-get 'prefix (pet-environment)))
                                            (env (car (member prefix (let-alist (pet-parse-json output) .envs)))))
                                       (or env
+                                          (pet-condaish-env-path)
                                           (user-error "Please create the environment with `$ %s create --file %s' first" program (pet-environment-path))))
                                   (user-error (buffer-string)))))
                           (error (pet-report-error err)))))

--- a/pet.el
+++ b/pet.el
@@ -116,7 +116,7 @@ and nil otherwise."
 (defcustom pet-condaish-root nil
   "Absolute path to the root directory where conda/(micro)mamba environments are stored."
   :group 'pet
-  :type string)
+  :type 'string)
 
 
 


### PR DESCRIPTION
Following up from https://github.com/wyuenho/emacs-pet/issues/32#issuecomment-2191654912_

Currently it's required for the `prefix` field to be set in a file's `environment.yml` in order for `pet-virtualenv-root` to find the right environment. I don't have this in any of my `environment.yml`s though, and it's keeping emacs-pet from finding the place where my environments live.  
https://github.com/wyuenho/emacs-pet/blob/cc086d91a9e6ab0158335d37a774356414746e17/pet.el#L605C1-L609C155

I could of course add a prefix line, and doing so fixes the issue, but if I'm working on a library that's going to be used by anybody else, that line shouldn't be getting checked into the repo. It would be nice if it were possible to point emacs-pet to the micromamba (or conda, mamba - I assume) root prefix in some other way.

This PR adds a custom variable `pet-condaish-root` that the user can set to point to whatever folder contains their `envs/`, and `pet-condaish-env-path` to check that as well as the environment variables `CONDA_ROOT` and `MAMBA_ROOT_PREFIX`  before `pet-virtualenv-root` errors out.

The prefix line in the `environment.yml` gets priority right now, then `pet-condaish-root`, and then the environmental variables, though I'm not sure if that's the best order or not.