### PR TITLE
fix an issue with non-file visiting buffers

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -963,7 +963,7 @@ buffer local values."
   (setq-local dap-python-executable python-shell-interpreter)
   (setq-local dap-variables-project-root-function #'pet-project-root)
   (setq-local dape-command
-              (if (file-exists-p (concat (file-name-directory (buffer-file-name)) "__main__.py"))
+              (if (and buffer-file-name (file-exists-p (concat (file-name-directory (buffer-file-name)) "__main__.py")))
                   `(debugpy-module command ,python-shell-interpreter)
                 `(debugpy command ,python-shell-interpreter)))
   (setq-local dape-cwd-fn #'pet-project-root)


### PR DESCRIPTION
Hello and thank you for this package.

This MR is a quick fix for an issue I'm facing with `pet-mode`. 

In some cases, there we can have temporary/special buffers with `python-mode` that doesn't visit a file (`buffer-file-name` is nil). In these cases, the current `pet-mode` gets called and cause an error.

This has been observed in `mmm-mode` when `python-mode` is used as a sub-mode, although, it can happen in other situations.