### PR TITLE
pipenv: Ignore additional pipenv output

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -633,7 +633,7 @@ Selects a virtualenv in the follow order:
                                  (default-directory (file-name-directory (pet-pipfile-path))))
                         (condition-case err
                             (with-temp-buffer
-                              (let ((exit-code (process-file program nil t nil "--venv"))
+                              (let ((exit-code (process-file program nil '(t nil) nil "--quiet" "--venv"))
                                     (output (string-trim (buffer-string))))
                                 (if (zerop exit-code)
                                     output

--- a/test/pet-test.el
+++ b/test/pet-test.el
@@ -790,7 +790,7 @@
     (spy-on 'call-process :and-call-fake (lambda (&rest _) (insert pipenv-virtualenv) 0))
     (expect (pet-virtualenv-root) :to-equal pipenv-virtualenv)
     (expect (assoc-default project-root pet-project-virtualenv-cache) :to-equal pipenv-virtualenv)
-    (expect 'call-process :to-have-been-called-with pipenv-path nil t nil "--venv"))
+    (expect 'call-process :to-have-been-called-with pipenv-path nil '(t nil) nil "--quiet" "--venv"))
 
   (it "should return the absolute path of the `.venv' or `venv' directory in a project"
     (spy-on 'pet-use-conda-p :and-return-value nil)


### PR DESCRIPTION
Pipenv can print additional output that would end up in our variables, e. g., if a `.env` file exists, `python-shell-virtualenv-root` ends up as `Loading .env environment variables...\n/home/user/.local/share/virtualenvs/project`.

This change is to:

1. call pipenv with `--quiet`, so that it does not print extra information in the first place;
2. pass `'(t nil)` as `buffer` argument to `process-file`, so that it ignores stderr and the buffer only contains stdout.

---

This issue may also exist with other backends, I did not check those.  On a side note, it would be cool if one could supply arbitrary backends, instead of hard-ish-coding everything in `pet-virtualenv-root`, but that’s probably a significant rewrite and a different issue.