### PR TITLE
Fix the ruff executable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -253,7 +253,7 @@ Complete Example
                  (setq-local python-pytest-executable (pet-executable-find "pytest"))
 
                  (when-let ((ruff-executable (pet-executable-find "ruff")))
-                   (setq-local ruff-format-command black-executable)
+                   (setq-local ruff-format-command ruff-executable)
                    (ruff-format-on-save-mode))
 
                  (when-let ((black-executable (pet-executable-find "black")))


### PR DESCRIPTION
Hello and thanks again for this amazing package!

At this point, `black-executable` is not defined and it should be `ruff-executable`.
