### PR TITLE
Fix: Hook into eglot-ensure, instead of eglot--executable-find

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -782,21 +782,9 @@ default otherwise."
 
 
 
-(defvar eglot-workspace-configuration)
 (declare-function jsonrpc--process "ext:jsonrpc")
-(declare-function eglot--executable-find "ext:eglot")
 (declare-function eglot--workspace-configuration-plist "ext:eglot")
 (declare-function eglot--guess-contact "ext:eglot")
-
-(defun pet-eglot--executable-find-advice (fn &rest args)
-  "Look up Python language servers using `pet-executable-find'.
-
-FN is `eglot--executable-find', ARGS is the arguments to
-`eglot--executable-find'."
-  (pcase-let ((`(,command . ,_) args))
-    (if (member command '("pylsp" "pyls" "pyright-langserver" "jedi-language-server" "ruff-lsp"))
-        (pet-executable-find command)
-      (apply fn args))))
 
 (defun pet-lookup-eglot-server-initialization-options (command)
   "Return LSP initializationOptions for Eglot.
@@ -882,7 +870,7 @@ COMMAND is the name of the Python language server command."
                   (copy-tree b t)))
 
 (defun pet-eglot--workspace-configuration-plist-advice (fn &rest args)
-  "Enrich `eglot-workspace-configuration' with paths found by `pet'.
+  "Enrich `eglot--workspace-configuration-plist' with paths found by `pet'.
 
 FN is `eglot--workspace-configuration-plist', ARGS is the
 arguments to `eglot--workspace-configuration-plist'."
@@ -924,13 +912,11 @@ FN is `eglot--guess-contact', ARGS is the arguments to
 
 (defun pet-eglot-setup ()
   "Set up Eglot to use server executables and virtualenvs found by PET."
-  (advice-add 'eglot--executable-find :around #'pet-eglot--executable-find-advice)
   (advice-add 'eglot--workspace-configuration-plist :around #'pet-eglot--workspace-configuration-plist-advice)
   (advice-add 'eglot--guess-contact :around #'pet-eglot--guess-contact-advice))
 
 (defun pet-eglot-teardown ()
   "Tear down PET advices to Eglot."
-  (advice-remove 'eglot--executable-find #'pet-eglot--executable-find-advice)
   (advice-remove 'eglot--workspace-configuration-plist #'pet-eglot--workspace-configuration-plist-advice)
   (advice-remove 'eglot--guess-contact #'pet-eglot--guess-contact-advice))
 

--- a/pet.el
+++ b/pet.el
@@ -786,7 +786,9 @@ default otherwise."
 (declare-function eglot--workspace-configuration-plist "ext:eglot")
 (declare-function eglot--guess-contact "ext:eglot")
 (declare-function eglot--lookup-mode "ext:eglot")
-
+;; We redefine this variable, originally defined in eglot.el, in our
+;; advice. See: `pet-eglot--lookup-mode-advice'.
+(defvar eglot-server-programs)
 (defun pet-lookup-eglot-server-initialization-options (command)
   "Return LSP initializationOptions for Eglot.
 

--- a/test/pet-test.el
+++ b/test/pet-test.el
@@ -996,34 +996,6 @@
     (expect (local-variable-p 'flycheck-python-pycompile-executable) :not :to-be-truthy)
     (expect (local-variable-p 'flycheck-python-ruff-executable) :not :to-be-truthy)))
 
-(describe "pet-eglot--executable-find-advice"
-  (it "should delegate to `pet-executable-find' for Python LSP servers"
-    (spy-on 'eglot--executable-find :and-call-fake (lambda (&rest args) (string-join args " ")))
-    (spy-on 'pet-executable-find :and-call-fake 'identity)
-
-    (expect (pet-eglot--executable-find-advice 'eglot--executable-find "pylsp") :to-equal "pylsp")
-    (expect (spy-context-return-value (spy-calls-most-recent 'pet-executable-find)) :to-equal "pylsp")
-    (expect 'eglot--executable-find :not :to-have-been-called)
-
-    (expect (pet-eglot--executable-find-advice 'eglot--executable-find "pyls") :to-equal "pyls")
-    (expect (spy-context-return-value (spy-calls-most-recent 'pet-executable-find)) :to-equal "pyls")
-    (expect 'eglot--executable-find :not :to-have-been-called)
-
-    (expect (pet-eglot--executable-find-advice 'eglot--executable-find "pyright-langserver") :to-equal "pyright-langserver")
-    (expect (spy-context-return-value (spy-calls-most-recent 'pet-executable-find)) :to-equal "pyright-langserver")
-    (expect 'eglot--executable-find :not :to-have-been-called)
-
-    (expect (pet-eglot--executable-find-advice 'eglot--executable-find "jedi-language-server") :to-equal "jedi-language-server")
-    (expect (spy-context-return-value (spy-calls-most-recent 'pet-executable-find)) :to-equal "jedi-language-server")
-    (expect 'eglot--executable-find :not :to-have-been-called)
-
-    (expect (pet-eglot--executable-find-advice 'eglot--executable-find "ruff-lsp") :to-equal "ruff-lsp")
-    (expect (spy-context-return-value (spy-calls-most-recent 'pet-executable-find)) :to-equal "ruff-lsp")
-    (expect 'eglot--executable-find :not :to-have-been-called)
-
-    (expect (pet-eglot--executable-find-advice 'eglot--executable-find "sh" "-c") :to-equal "sh -c")
-    (expect 'eglot--executable-find :to-have-been-called-with "sh" "-c")))
-
 (describe "pet-eglot--workspace-configuration-plist-advice"
   (before-each
     (spy-on 'jsonrpc--process))
@@ -1277,7 +1249,6 @@
   (it "should advice eglot functions"
     (pet-eglot-setup)
     (expect (advice-member-p 'pet-eglot--workspace-configuration-plist-advice 'eglot--workspace-configuration-plist) :to-be-truthy)
-    (expect (advice-member-p 'pet-eglot--executable-find-advice 'eglot--executable-find) :to-be-truthy)
     (expect (advice-member-p 'pet-eglot--guess-contact-advice 'eglot--guess-contact) :to-be-truthy)))
 
 (describe "pet-eglot-teardown"
@@ -1285,7 +1256,6 @@
     (pet-eglot-setup)
     (pet-eglot-teardown)
     (expect (advice-member-p 'pet-eglot--workspace-configuration-plist-advice 'eglot--workspace-configuration-plist) :to-be nil)
-    (expect (advice-member-p 'pet-eglot--executable-find-advice 'eglot--executable-find) :to-be nil)
     (expect (advice-member-p 'pet-eglot--guess-contact-advice 'eglot--guess-contact) :to-be nil)))
 
 (describe "pet-dape-setup"


### PR DESCRIPTION
`eglot--executable-find` was an internal function that has been removed in the latest version of Eglot (1.17). Due to this, `emacs-pet` no longer works with Eglot correctly, since it's advice is not used anymore. #50

In this commit, we fix the issue by making the following changes:

1. Extract the internals of `pet-executable-find` into an independent function `pet-adjust-path-executable-find`.
   - This function creates a buffer-local variants of `exec-path` and `tramp-remote-path` variables, and add venv paths found by pet. Eglot can now find the path to the right executables correctly.
   - We also remove calls to `setenv PATH`, since we don't need to modify a  global system setting to make venv executables available to Eglot.

2. Remove all references to unused or non-existent eglot variables.
   - `eglot--executable-find` no longer exists.
   - `eglot--uri-to-path` is not used by `pet`.

3. Modify `pet-executable-find` to use our new function `pet-adjust-paths-executable-find`.

4. Advice `eglot-ensure`, which is an Eglot public API that is always called when starting an LSP server.
   - We are no longer depending on internal variables / functions for this, and so the Eglot code is now a bit more future-proof.

I've tested this change as follows:

1. Tested against Python projects using the following types of scaffolding:
   - poetry
   - Manual venv creation
2. Tested against Eglot versions 1.17 and 1.16 (Emacs versions 31 and 29)
3. I could not get `make test` to run correctly, because of native compilation / Emacs 31 issues.