### PR TITLE
fix(dape): Use latest aliases

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -936,7 +936,7 @@ FN is `eglot--guess-contact', ARGS is the arguments to
 
 
 (defvar dape-command)
-(defvar dape-cwd-fn)
+(defvar dape-cwd-function)
 
 (defun pet-dape-setup ()
   "Set up the buffer local variables for `dape'."
@@ -951,12 +951,12 @@ FN is `eglot--guess-contact', ARGS is the arguments to
                       (string-join module "."))))
       (setq-local dape-command `(debugpy-module command ,(pet-executable-find "python") :module ,module))
     (setq-local dape-command `(debugpy command ,(pet-executable-find "python"))))
-  (setq-local dape-cwd-fn #'pet-project-root))
+  (setq-local dape-cwd-function #'pet-project-root))
 
 (defun pet-dape-teardown ()
   "Tear down the buffer local variables for `dape'."
   (kill-local-variable 'dape-command)
-  (kill-local-variable 'dape-cwd-fn))
+  (kill-local-variable 'dape-cwd-function))
 
 
 
@@ -1078,7 +1078,7 @@ has assigned to."
                        dap-python-executable
                        dap-variables-project-root-function
                        dape-command
-                       dape-cwd-fn
+                       dape-cwd-function
                        python-pytest-executable
                        python-black-command
                        blacken-executable

--- a/test/pet-test.el
+++ b/test/pet-test.el
@@ -1308,10 +1308,10 @@
     (expect (local-variable-p 'dape-command) :to-be-truthy)
     (expect dape-command :to-equal '(debugpy-module command "/usr/bin/python" :module "foo.bar")))
 
-  (it "should set up buffer local variable dape-cwd-fn"
+  (it "should set up buffer local variable dape-cwd-function"
     (pet-dape-setup)
-    (expect (local-variable-p 'dape-cwd-fn) :to-be-truthy)
-    (expect dape-cwd-fn :to-equal 'pet-project-root)))
+    (expect (local-variable-p 'dape-cwd-function) :to-be-truthy)
+    (expect dape-cwd-function :to-equal 'pet-project-root)))
 
 (describe "pet-dape-teardown"
   (it "should tear down bufer local variables for dape"
@@ -1320,7 +1320,7 @@
     (pet-dape-setup)
     (pet-dape-teardown)
     (expect (local-variable-p 'dape-command) :not :to-be-truthy)
-    (expect (local-variable-p 'dape-cwd-fn) :not :to-be-truthy)))
+    (expect (local-variable-p 'dape-cwd-function) :not :to-be-truthy)))
 
 (describe "pet-buffer-local-vars-setup"
   (after-each


### PR DESCRIPTION
In the latest release of dape, `0.21.0` [1], they've obsoleted the previous `*-fn` commands [2].

I've done a simple find-and-replace, and tested locally on my machine.

[1] https://github.com/svaante/dape/commit/70d5db46325e9642f6a25730a79f3d0ae38c7eb7
[2] https://github.com/svaante/dape/commit/6a55b489dd97a909b3ba984a67c5627b9eb9d67f
