### PR TITLE
Use default python-shell-interpreter

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -982,7 +982,7 @@ FN is `eglot--guess-contact', ARGS is the arguments to
 
 Assign all supported Python tooling executable variables to
 buffer local values."
-  (setq-local python-shell-interpreter (pet-executable-find "python"))
+  (setq-local python-shell-interpreter (pet-executable-find python-shell-interpreter))
   (setq-local python-shell-virtualenv-root (pet-virtualenv-root))
 
   (pet-flycheck-setup)


### PR DESCRIPTION
Hi and thanks for the amazing package!

It might be a dumb pull request and there might be a good reason why it's not set up this way, so feel free to ignore and close.

I've read on the README that you can set up the `python-shell-interpreter`, but I didn't get why the default wasn't to look for the default `python-shell-interpreter`, it felt more intuitive to me. 
(I'm setting `python-shell-interpreter` to `ipython`)

I've tested it while changing projects and didn't encounter any particular issue.

Please let me know if you think it makes sense and if it requires more than just this simple change. I can definitely do more extensive testing!
