### PR TITLE
Prefer ipython as the default shell interpreter if available

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -982,7 +982,13 @@ FN is `eglot--guess-contact', ARGS is the arguments to
 
 Assign all supported Python tooling executable variables to
 buffer local values."
-  (setq-local python-shell-interpreter (pet-executable-find "python"))
+  ;; Look for the correct shell interpreter prefering ipython
+  (let* ((pyshell (or (pet-executable-find "ipython")
+                      (pet-executable-find "python")))
+         (ipythonp (string-search "ipython" (file-name-nondirectory pyshell))))
+    (setq-local python-shell-interpreter pyshell
+                python-shell-interpreter-args (if ipythonp "-i --simple-prompt" "-i")))
+
   (setq-local python-shell-virtualenv-root (pet-virtualenv-root))
 
   (pet-flycheck-setup)


### PR DESCRIPTION
Updated the logic to prioritize `ipython` as the Python shell interpreter. If `ipython` is found, it is set with appropriate arguments; otherwise, it falls back to `python`.

This ensures better compatibility with interactive Python sessions.