### PR TITLE
fix: prevent cross-project conda environment variable pollution

### DIFF
--- a/test/pet-conda-switch-environment-test.el
+++ b/test/pet-conda-switch-environment-test.el
@@ -73,43 +73,29 @@
       (expect 'message :to-have-been-called-with
               "Switched to %s environment: %s" "conda" env-path)))
 
-  (describe "environment variable handling"
-    (it "should set CONDA_PREFIX environment variable in project buffers"
+  (describe "cache handling"
+    (it "should cache the selected environment for the project"
       (spy-on 'pet-buffer-local-vars-teardown)
       (spy-on 'pet-buffer-local-vars-setup)
       (spy-on 'buffer-list :and-return-value (list buffer-a buffer-b))
 
       (pet-conda-switch-environment env-path)
 
-      (with-current-buffer buffer-a
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path))
-      (with-current-buffer buffer-b
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path)))
+      (expect (pet-cache-get (list project-root :virtualenv)) :to-equal env-path))
 
-    (it "should preserve other environment variables while updating CONDA_PREFIX"
-      (spy-on 'buffer-list :and-return-value (list buffer-a))
-      (spy-on 'pet-buffer-local-vars-teardown)
-      (spy-on 'pet-buffer-local-vars-setup)
-
-      (pet-conda-switch-environment env-path)
-
-      (with-current-buffer buffer-a
-        (expect (getenv "PATH") :to-equal "/usr/bin")
-        (expect (getenv "HOME") :to-equal "/home/user")
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path))))
 
   (describe "buffer isolation"
-    (it "should not affect buffers from other projects"
+    (it "should only refresh variables for buffers from the same project"
       (spy-on 'buffer-list :and-return-value (list buffer-a other-project-buffer))
       (spy-on 'pet-buffer-local-vars-teardown)
       (spy-on 'pet-buffer-local-vars-setup)
 
       (pet-conda-switch-environment env-path)
 
-      (with-current-buffer buffer-a
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path))
-      (with-current-buffer other-project-buffer
-        (expect (getenv "CONDA_PREFIX") :to-equal "/other/old/env"))))
+      ;; Should only call teardown/setup once per project buffer (buffer-a only)
+      ;; other-project-buffer should be ignored because it's from different project
+      (expect 'pet-buffer-local-vars-teardown :to-have-been-called-times 1)
+      (expect 'pet-buffer-local-vars-setup :to-have-been-called-times 1)))
 
   (describe "interactive completion"
     (it "should prompt with available environments"
@@ -153,5 +139,5 @@
       (pet-conda-switch-environment env-path)
 
       (expect (pet-cache-get (list project-root :virtualenv)) :to-equal env-path)
-      (expect 'pet-buffer-local-vars-teardown :not :to-have-been-called))))
+      (expect 'pet-buffer-local-vars-teardown :not :to-have-been-called)))))
 

--- a/test/pet-conda-venv-p-test.el
+++ b/test/pet-conda-venv-p-test.el
@@ -1,0 +1,41 @@
+;; -*- lexical-binding: t; -*-
+
+(require 'pet)
+
+(describe "pet-conda-venv-p"
+  (it "should return t for conda environments with conda-meta directory"
+    (spy-on 'file-exists-p :and-call-fake
+            (lambda (path)
+              (equal path "/home/user/anaconda3/envs/myenv/conda-meta")))
+    
+    (expect (pet-conda-venv-p "/home/user/anaconda3/envs/myenv") :to-be-truthy))
+
+  (it "should return t for mamba environments with conda-meta directory"
+    (spy-on 'file-exists-p :and-call-fake
+            (lambda (path)
+              (equal path "/home/user/micromamba/envs/test/conda-meta")))
+    
+    (expect (pet-conda-venv-p "/home/user/micromamba/envs/test") :to-be-truthy))
+
+  (it "should return t for pixi environments with conda-meta directory"
+    (spy-on 'file-exists-p :and-call-fake
+            (lambda (path)
+              (equal path "/home/user/project/.pixi/envs/default/conda-meta")))
+    
+    (expect (pet-conda-venv-p "/home/user/project/.pixi/envs/default") :to-be-truthy))
+
+  (it "should return nil for traditional virtualenvs without conda-meta directory"
+    (spy-on 'file-exists-p :and-return-value nil)
+    
+    (expect (pet-conda-venv-p "/home/user/project/.venv") :to-be nil))
+
+  (it "should return nil for nil input"
+    (expect (pet-conda-venv-p nil) :to-be nil))
+
+  (it "should handle paths with and without trailing slashes"
+    (spy-on 'file-exists-p :and-call-fake
+            (lambda (path)
+              (equal path "/home/user/anaconda3/envs/myenv/conda-meta")))
+    
+    (expect (pet-conda-venv-p "/home/user/anaconda3/envs/myenv") :to-be-truthy)
+    (expect (pet-conda-venv-p "/home/user/anaconda3/envs/myenv/") :to-be-truthy)))

--- a/test/pet-executable-find-test.el
+++ b/test/pet-executable-find-test.el
@@ -99,7 +99,7 @@
     (it "should return the absolute path to the python executable for a conda project if its virtualenv is found"
       (spy-on 'pet-use-pre-commit-p )
       (spy-on 'pet-virtualenv-root :and-return-value "C:/Users/user/Anaconda3/envs/project/")
-      (spy-on 'pet-use-conda-p :and-return-value t)
+      (spy-on 'pet-conda-venv-p :and-return-value t)
       (spy-on 'pet-system-bin-dir)
       (spy-on 'executable-find :and-return-value "C:/Users/user/Anaconda3/envs/project/python")
       (expect (pet-executable-find "python") :to-equal "C:/Users/user/Anaconda3/envs/project/python")

--- a/test/pet-mamba-switch-environment-test.el
+++ b/test/pet-mamba-switch-environment-test.el
@@ -72,43 +72,28 @@
       (expect 'message :to-have-been-called-with
               "Switched to %s environment: %s" "mamba" env-path)))
 
-  (describe "environment variable handling"
-    (it "should set CONDA_PREFIX environment variable in project buffers"
+  (describe "cache handling"
+    (it "should cache the selected environment for the project"
       (spy-on 'pet-buffer-local-vars-teardown)
       (spy-on 'pet-buffer-local-vars-setup)
       (spy-on 'buffer-list :and-return-value (list buffer-a buffer-b))
 
       (pet-mamba-switch-environment env-path)
 
-      (with-current-buffer buffer-a
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path))
-      (with-current-buffer buffer-b
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path)))
-
-    (it "should preserve other environment variables while updating CONDA_PREFIX"
-      (spy-on 'buffer-list :and-return-value (list buffer-a))
-      (spy-on 'pet-buffer-local-vars-teardown)
-      (spy-on 'pet-buffer-local-vars-setup)
-
-      (pet-mamba-switch-environment env-path)
-
-      (with-current-buffer buffer-a
-        (expect (getenv "PATH") :to-equal "/usr/bin")
-        (expect (getenv "HOME") :to-equal "/home/user")
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path))))
+      (expect (pet-cache-get (list project-root :virtualenv)) :to-equal env-path)))
 
   (describe "buffer isolation"
-    (it "should not affect buffers from other projects"
+    (it "should only refresh variables for buffers from the same project"
       (spy-on 'buffer-list :and-return-value (list buffer-a other-project-buffer))
       (spy-on 'pet-buffer-local-vars-teardown)
       (spy-on 'pet-buffer-local-vars-setup)
 
       (pet-mamba-switch-environment env-path)
 
-      (with-current-buffer buffer-a
-        (expect (getenv "CONDA_PREFIX") :to-equal env-path))
-      (with-current-buffer other-project-buffer
-        (expect (getenv "CONDA_PREFIX") :to-equal "/other/old/env"))))
+      ;; Should only call teardown/setup once per project buffer (buffer-a only)
+      ;; other-project-buffer should be ignored because it's from different project
+      (expect 'pet-buffer-local-vars-teardown :to-have-been-called-times 1)
+      (expect 'pet-buffer-local-vars-setup :to-have-been-called-times 1)))
 
   (describe "interactive completion"
     (it "should prompt with available environments"

--- a/test/pet-virtualenv-root-test.el
+++ b/test/pet-virtualenv-root-test.el
@@ -42,29 +42,6 @@
     (spy-on 'getenv :and-call-fake (lambda (name) (when (equal name "VIRTUAL_ENV") "/home/user/.venvs/project")))
     (expect (pet-virtualenv-root) :to-equal "/home/user/.venvs/project"))
 
-  (it "should return the absolute path of the virtualenv for a project using `conda'"
-    (spy-on 'pet-use-pixi-p )
-    (spy-on 'pet-use-conda-p :and-return-value conda-path)
-    (spy-on 'pet-use-mamba-p )
-    (spy-on 'getenv :and-call-fake (lambda (name) (when (equal name "CONDA_PREFIX") conda-virtualenv)))
-    (expect (pet-virtualenv-root) :to-equal conda-virtualenv)
-    (expect (pet-cache-get (list project-root :virtualenv)) :to-equal conda-virtualenv))
-
-  (it "should return the absolute path of the virtualenv for a project using `mamba'"
-    (spy-on 'pet-use-pixi-p )
-    (spy-on 'pet-use-conda-p )
-    (spy-on 'pet-use-mamba-p :and-return-value mamba-path)
-    (spy-on 'getenv :and-call-fake (lambda (name) (when (equal name "CONDA_PREFIX") mamba-virtualenv)))
-    (expect (pet-virtualenv-root) :to-equal mamba-virtualenv)
-    (expect (pet-cache-get (list project-root :virtualenv)) :to-equal mamba-virtualenv))
-
-  (it "should return the absolute path of the virtualenv for a project using `pixi'"
-    (spy-on 'pet-use-pixi-p :and-return-value pixi-path)
-    (spy-on 'pet-use-conda-p )
-    (spy-on 'pet-use-mamba-p )
-    (spy-on 'getenv :and-call-fake (lambda (name) (when (equal name "CONDA_PREFIX") pixi-virtualenv)))
-    (expect (pet-virtualenv-root) :to-equal pixi-virtualenv)
-    (expect (pet-cache-get (list project-root :virtualenv)) :to-equal pixi-virtualenv))
 
   (it "should return the absolute path of the virtualenv for a project using `poetry'"
     (spy-on 'pet-use-pixi-p )


### PR DESCRIPTION
## Summary
- Fixes cross-project environment variable pollution where `CONDA_PREFIX` contaminated other projects
- Replaces config-based conda detection with directory-based detection using `conda-meta/` directory
- Conda environments no longer auto-detected during virtualenv discovery but work normally when selected

🤖 Generated with [Claude Code](https://claude.ai/code)