### PR TITLE
Use gethash for format-all executable lookup

### DIFF
--- a/pet.el
+++ b/pet.el
@@ -1804,7 +1804,7 @@ has assigned to."
                (if (boundp 'format-all--executable-table)
                    (list "\n"
                          (pp-to-string
-                          (mapcar (lambda (key) (alist-get key format-all--executable-table))
+                          (mapcar (lambda (key) (gethash key format-all--executable-table))
                                   '(black isort ruff yapf))))
                  (list (format "%s\n" 'unbound)))))
 


### PR DESCRIPTION
Previously the code used alist-get to retrieve entries from format-all--executable-table. That variable is a hash table, so alist-get fails. This change replaces alist-get with gethash to query the hash table and restore correct lookup and output.

This was a bug introduced in b6b80979fd0632917180befb92eb6a63d520a463, where gethash was replaced by alist-get.